### PR TITLE
Simplify task base, preparing for slicing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,13 @@ This release will depend on ``baseband`` 4.0 as one can then assume
 (and document) the existence of ``baseband.tasks``.  Like baseband 4.0,
 it will also require python 3.7, astropy 4.0, and numpy 1.17.
 
+Other Changes and Additions
+---------------------------
+
+- Tasks can now be defined with a number of complete samples (``shape[0]``)
+  that is not an integer multiple of ``samples_per_frame``, which can be
+  used to avoid losing ends of streams for tasks that can handle dealing
+  with partial frames. [#188]
 
 0.1.1 (2020-07-19)
 ==================

--- a/baseband_tasks/conversion.py
+++ b/baseband_tasks/conversion.py
@@ -23,7 +23,8 @@ class Real2Complex(TaskBase):
     ih : task or `baseband` stream reader
         Input data stream, with time as the first axis.
     samples_per_frame : int, optional
-        Number of complete output samples per frame (see Notes).  Default: 1.
+        Number of complete output samples per frame (see Notes).
+        Default: Half the number of samples per frame in the input stream.
 
     See Also
     --------

--- a/baseband_tasks/convolution.py
+++ b/baseband_tasks/convolution.py
@@ -93,14 +93,14 @@ class Convolve(ConvolveSamples):
                          samples_per_frame=samples_per_frame)
         # Initialize FFTs for fine channelization and the inverse.
         self._FFT = fft_maker.get()
-        self._fft = self._FFT(shape=(self._padded_samples_per_frame,)
+        self._fft = self._FFT(shape=(self._ih_samples_per_frame,)
                               + self.ih.sample_shape, dtype=self.ih.dtype,
                               sample_rate=self.ih.sample_rate)
         self._ifft = self._fft.inverse()
 
     @lazyproperty
     def _ft_response(self):
-        long_response = np.zeros((self._padded_samples_per_frame,)
+        long_response = np.zeros((self._ih_samples_per_frame,)
                                  + self._response.shape[1:], self.dtype)
         long_response[:self._response.shape[0]] = self._response
         fft = self._FFT(shape=long_response.shape, dtype=self.dtype)

--- a/baseband_tasks/convolution.py
+++ b/baseband_tasks/convolution.py
@@ -25,17 +25,17 @@ class ConvolveSamples(PaddedTaskBase):
         of 0, a given sample has the same time as the convolution of the filter
         with all preceding samples.
     samples_per_frame : int, optional
-        Number of samples which should be convolved in one go. The number of
-        output convolved samples per frame will be smaller to avoid wrapping.
-        If not given, the minimum power of 2 needed to get at least 75%
-        efficiency.
+        Number of convolved samples which should be produced in one go.
+        The number of input samples used will be larger to avoid wrapping.
+        If not given, as produced by the minimum power of 2 of input
+        samples that yields at least 75% efficiency.
 
     See Also
     --------
     Convolve : convolution in the Fourier domain (usually faster)
     """
 
-    def __init__(self, ih, response, offset=0, samples_per_frame=None):
+    def __init__(self, ih, response, *, offset=0, samples_per_frame=None):
         if response.ndim == 1 and ih.ndim > 1:
             response = response.reshape(response.shape[:1]
                                         + (1,) * (ih.ndim - 1))
@@ -77,10 +77,10 @@ class Convolve(ConvolveSamples):
         of 0, a given sample has the same time as the convolution of the filter
         with all preceding samples.
     samples_per_frame : int, optional
-        Number of samples which should be convolved in one go. The number of
-        output convolved samples per frame will be smaller to avoid wrapping.
-        If not given, the minimum power of 2 needed to get at least 75%
-        efficiency.
+        Number of convolved samples which should be produced in one go.
+        The number of input samples used will be larger to avoid wrapping.
+        If not given, as produced by the minimum power of 2 of input
+        samples that yields at least 75% efficiency.
 
     See Also
     --------

--- a/baseband_tasks/dispersion.py
+++ b/baseband_tasks/dispersion.py
@@ -97,7 +97,7 @@ class Disperse(PaddedTaskBase):
 
         # Initialize FFTs for fine channelization and the inverse.
         # TODO: remove duplication with Convolve.
-        self._fft = fft_maker(shape=(self._padded_samples_per_frame,)
+        self._fft = fft_maker(shape=(self._ih_samples_per_frame,)
                               + self.ih.sample_shape, dtype=self.ih.dtype,
                               sample_rate=self.ih.sample_rate)
         self._ifft = self._fft.inverse()
@@ -106,7 +106,7 @@ class Disperse(PaddedTaskBase):
         self._sample_offset = sample_offset
         self._start_time += sample_offset / ih.sample_rate
         self._pad_slice = slice(self._pad_start,
-                                self._padded_samples_per_frame - self._pad_end)
+                                self._pad_start + self.samples_per_frame)
 
     @lazyproperty
     def phase_factor(self):

--- a/baseband_tasks/dispersion.py
+++ b/baseband_tasks/dispersion.py
@@ -26,10 +26,10 @@ class Disperse(PaddedTaskBase):
         Frequency to which the data should be dispersed.  Can be an array.
         By default, the mean frequency.
     samples_per_frame : int, optional
-        Number of samples which should be dispersed in one go. The number of
-        output dispersed samples per frame will be smaller to avoid wrapping.
-        If not given, the minimum power of 2 needed to get at least 75%
-        efficiency.
+        Number of dispersed samples which should be produced in one go.
+        The number of input samples used will be larger to avoid wrapping.
+        If not given, as produced by the minimum power of 2 of input
+        samples that yields at least 75% efficiency.
     frequency : `~astropy.units.Quantity`, optional
         Frequencies for each channel in ``ih`` (channelized frequencies will
         be calculated).  Default: taken from ``ih`` (if available).
@@ -42,7 +42,7 @@ class Disperse(PaddedTaskBase):
     baseband_tasks.fourier.fft_maker : to select the FFT package used.
     """
 
-    def __init__(self, ih, dm, reference_frequency=None,
+    def __init__(self, ih, dm, *, reference_frequency=None,
                  samples_per_frame=None, frequency=None, sideband=None):
         dm = DispersionMeasure(dm)
         if frequency is None:
@@ -153,10 +153,10 @@ class Dedisperse(Disperse):
         By default, the mean frequency.  If one doesn't want to change the
         start time, choose the maximum frequency.
     samples_per_frame : int, optional
-        Number of samples which should be dedispersed in one go. The number of
-        output dedispersed samples per frame will be smaller to avoid wrapping.
-        If not given, the minimum power of 2 needed to get at least 75%
-        efficiency.
+        Number of dedispersed samples which should be produced in one go.
+        The number of input samples used will be larger to avoid wrapping.
+        If not given, as produced by the minimum power of 2 of input
+        samples that yields at least 75% efficiency.
     frequency : `~astropy.units.Quantity`, optional
         Frequencies for each channel in ``ih`` (channelized frequencies will
         be calculated).  Default: taken from ``ih`` (if available).
@@ -172,5 +172,6 @@ class Dedisperse(Disperse):
 
     def __init__(self, ih, dm, reference_frequency=None,
                  samples_per_frame=None, frequency=None, sideband=None):
-        super().__init__(ih, -dm, reference_frequency, samples_per_frame,
-                         frequency, sideband)
+        super().__init__(ih, -dm, reference_frequency=reference_frequency,
+                         samples_per_frame=samples_per_frame,
+                         frequency=frequency, sideband=sideband)

--- a/baseband_tasks/integration.py
+++ b/baseband_tasks/integration.py
@@ -118,7 +118,7 @@ class Integrate(BaseTaskBase):
                 step = ih_n_sample
 
             sample_rate = ih.sample_rate / step
-            shape = (ih_n_sample // step,) + ih.sample_shape
+            n_sample = ih_n_sample // step
             # Initialize values for _get_offsets.
             self._mean_offset_size = 1. / step
 
@@ -137,10 +137,13 @@ class Integrate(BaseTaskBase):
 
             sample_rate = 1. / step
             n_sample = ((stop - start) / step).to_value(u.one)
-            shape = (int(n_sample),) + ih.sample_shape
             # Initialize values for _get_offsets.
             self._mean_offset_size = n_sample / ih_n_sample
             self._start = start
+
+        n_sample = (n_sample // samples_per_frame) * samples_per_frame
+        assert n_sample >= 1, "time per frame larger than total time in stream"
+        shape = (int(n_sample),) + ih.sample_shape
 
         if dtype is None:
             if average:

--- a/baseband_tasks/sampling.py
+++ b/baseband_tasks/sampling.py
@@ -42,7 +42,7 @@ def float_offset(ih, offset, whence=0):
 
 
 class Resample(PaddedTaskBase):
-    """Rsample a stream such that a sample occurs at the given offset.
+    """Resample a stream such that a sample occurs at the given offset.
 
     The offset pointer is left at the requested time.
 
@@ -60,9 +60,10 @@ class Resample(PaddedTaskBase):
         'current', or 'end' for 0, 1, or 2, respectively.  Ignored if
         ``offset`` is a time.
     samples_per_frame : int, optional
-        Number of samples which should be resampled in one go. The number of
-        output samples per frame will be one less than this.  If not given,
-        the larger of the sampler per frame in the underlying stream or 1024.
+        Number of resampled samples which should be produced in one go.
+        The number of input samples used will be larger to avoid wrapping.
+        If not given, works on the larger of the samples per frame from
+        the underlying stream or 1024.
 
     Examples
     --------
@@ -114,7 +115,7 @@ class Resample(PaddedTaskBase):
             pad_start, pad_end = 0, 1
 
         if samples_per_frame is None:
-            samples_per_frame = max(ih.samples_per_frame, 1024)
+            samples_per_frame = max(ih.samples_per_frame-1, 1023)
 
         super().__init__(ih, pad_start=pad_start, pad_end=pad_end,
                          samples_per_frame=samples_per_frame)

--- a/baseband_tasks/sampling.py
+++ b/baseband_tasks/sampling.py
@@ -120,7 +120,7 @@ class Resample(PaddedTaskBase):
         super().__init__(ih, pad_start=pad_start, pad_end=pad_end,
                          samples_per_frame=samples_per_frame)
 
-        self._fft = fft_maker(shape=(self._padded_samples_per_frame,)
+        self._fft = fft_maker(shape=(self._ih_samples_per_frame,)
                               + ih.sample_shape, sample_rate=ih.sample_rate,
                               dtype=ih.dtype)
         self._ifft = self._fft.inverse()
@@ -128,7 +128,7 @@ class Resample(PaddedTaskBase):
         self._fraction = fraction
         self._start_time += fraction / ih.sample_rate
         self._pad_slice = slice(self._pad_start,
-                                self._padded_samples_per_frame - self._pad_end)
+                                self._pad_start + self.samples_per_frame)
         self.seek(int(rounded_offset) - self._pad_start)
 
     @lazyproperty

--- a/baseband_tasks/tests/test_base.py
+++ b/baseband_tasks/tests/test_base.py
@@ -56,10 +56,10 @@ class SquareHat(PaddedTaskBase):
     `SquareHat` simply convolves with a set of 1s of given length.
     """
 
-    def __init__(self, ih, n, offset=0, samples_per_frame=None):
+    def __init__(self, ih, n, offset=0, **kwargs):
         self._n = n
         super().__init__(ih, pad_start=n-1-offset, pad_end=offset,
-                         samples_per_frame=samples_per_frame)
+                         **kwargs)
 
     def task(self, data):
         size = data.shape[0]
@@ -421,7 +421,5 @@ class TestPaddedTaskBase(UseVDIFSample):
             SquareHat(self.fh, -1)
         with pytest.raises(ValueError):
             SquareHat(self.fh, 10, offset=-1)
-        with pytest.raises(ValueError):
-            SquareHat(self.fh, 10, samples_per_frame=9)
         with pytest.warns(UserWarning, match='inefficient'):
-            SquareHat(self.fh, 10, samples_per_frame=11)
+            SquareHat(self.fh, 10, samples_per_frame=8)

--- a/baseband_tasks/tests/test_base.py
+++ b/baseband_tasks/tests/test_base.py
@@ -24,8 +24,7 @@ class ReshapeTime(TaskBase):
         samples_per_frame = operator.index(samples_per_frame)
         sample_rate = ih.sample_rate / n
 
-        nsample = samples_per_frame * (ih.shape[0] // n // samples_per_frame)
-        super().__init__(ih, shape=(nsample, n) + ih.shape[1:],
+        super().__init__(ih, shape=(-1, n) + ih.shape[1:],
                          sample_rate=sample_rate,
                          samples_per_frame=samples_per_frame, **kwargs)
 

--- a/baseband_tasks/tests/test_convolution.py
+++ b/baseband_tasks/tests/test_convolution.py
@@ -20,9 +20,9 @@ class TestConvolveDADA(UseDADASample):
         ref_data = fh.read()
         expected = ref_data[:-2] + ref_data[1:-1] + ref_data[2:]
 
-        # Have 16000 - 2 useful samples -> can use 842, but add 2 for response.
+        # Have 16000 - 2 useful samples -> can use 842.
         response = np.ones(3)
-        ct = convolve_task(fh, response, samples_per_frame=844)
+        ct = convolve_task(fh, response, samples_per_frame=842)
         # Convolve everything.
         data1 = ct.read()
         assert ct.tell() == ct.shape[0] == fh.shape[0] - 2
@@ -72,9 +72,9 @@ class TestConvolveNoise:
     @pytest.mark.parametrize('convolve_task', (ConvolveSamples, Convolve))
     def test_different_response(self, convolve_task):
         response = np.array([[1., 1., 1.], [1., 1., 0.]]).T
-        ct = convolve_task(self.nh, response, samples_per_frame=844)
-        assert abs(ct.start_time
-                   - self.start_time - 2 / self.sample_rate) < 1. * u.ns
+        ct = convolve_task(self.nh, response, samples_per_frame=842)
+        assert abs(ct.start_time - self.start_time
+                   - 2 / self.sample_rate) < 1. * u.ns
         expected = (self.data[:-2] * np.array([1, 0]) + self.data[1:-1]
                     + self.data[2:])
         data1 = ct.read()

--- a/baseband_tasks/tests/test_sampling.py
+++ b/baseband_tasks/tests/test_sampling.py
@@ -62,7 +62,7 @@ class TestResampleReal:
                               10.*u.ms, 0.015*u.s,
                               Time('2010-11-12T13:14:15.013')))
     def test_resample(self, offset):
-        ih = Resample(self.part_fh, offset, samples_per_frame=512)
+        ih = Resample(self.part_fh, offset, samples_per_frame=511)
         # Always lose 1 sample per frame.
         assert ih.shape == ((self.part_fh.shape[0] - 1,)
                             + self.part_fh.sample_shape)


### PR DESCRIPTION
The main change is for simple tasks to allow `shape[0]` to be a non-integer multiple of `samples_per_frame` - obviously only for tasks which can handle variable number of samples.