### PR TITLE
Fix time for phase integration.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,13 @@ New Features
 - ``SetAttribute`` can now also be used to change ``samples_per_frame``,
   ``shape`` or ``dtype``. [#195]
 
+Bug Fixes
+---------
+
+- Time will now be reported correctly also for ``Stack`` and ``Integrate``
+  even if their sample rate is not in Hz. Times will be accurate to the
+  nearest sample of the underlying stream. [#197]
+
 Other Changes and Additions
 ---------------------------
 

--- a/baseband_tasks/shaping.py
+++ b/baseband_tasks/shaping.py
@@ -396,8 +396,10 @@ class GetSlice(GetItem):
             self.task = lambda data: data
 
         self._start = start
-        self._start_time = self.start_time + start / self.sample_rate
         self._shape = (stop-start,)+self.shape[1:]
+
+    def _tell_time(self, offset):
+        return self.ih._tell_time(self._start + offset)
 
     def _get_frame(self, offset):
         return super()._get_frame(self._start + offset)


### PR DESCRIPTION
Done with the usual indirection, by creating a new _tell_time method which is used by everything that needs times and can be overridden by subclasses.