### PR TITLE
Bug fixes to predictor.py

### DIFF
--- a/baseband_tasks/phases/predictor.py
+++ b/baseband_tasks/phases/predictor.py
@@ -160,7 +160,7 @@ class Polyco(QTable):
         """
         _user_defined_index = index is not None
         time = Time(time, format='mjd', scale='utc')
-        
+
         try:  # This also catches index=None
             index = index.__index__()
         except (AttributeError, TypeError):

--- a/baseband_tasks/phases/predictor.py
+++ b/baseband_tasks/phases/predictor.py
@@ -61,6 +61,7 @@ Example tempo2 call to produce one:
 """
 
 from collections import OrderedDict
+import os
 
 import numpy as np
 from numpy.polynomial import Polynomial
@@ -78,15 +79,9 @@ __all__ = ['Polyco']
 
 
 class Polyco(QTable):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, data, *args, **kwargs):
         """Read in polyco file as Table, and set up class."""
-        if len(args):
-            data = args[0]
-            args = args[1:]
-        else:
-            data = kwargs.pop('data', None)
-
-        if isinstance(data, str):
+        if isinstance(data, (str, bytes, os.PathLike)):
             data = polyco2table(data)
 
         super().__init__(data, *args, **kwargs)
@@ -173,8 +168,6 @@ class Polyco(QTable):
 
         # Convert offsets to minutes for later use in polynomial evaluation.
         dt = (time - self['mjd_mid'][index]).to(u.min)
-        if np.any(dt > self['span'][index]/2):
-            raise ValueError('(some) MJD outside of polyco range')
 
         # Check whether we need to add the reference phase at the end.
         do_phase = (deriv == 0 and rphase is None)


### PR DESCRIPTION
Deals with #200:

Adds 1 ms leeway for timestamps being outside Polyco entry spans. This is more than enough to deal with any inaccuracy in MJD value. This should effectively fill in all the gaps. But only checks for this if the index isn't user-defined, allowing the user to stupidly choose whatever index they want.

Additionally, a bunch of other minor code-fixes such as handling PathLike objects that aren't necessarily strings.