### PR TITLE
Use generic 4.0.* for oldest astropy version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -86,7 +86,10 @@ addopts = -rx --doctest-rst --doctest-ignore-import-errors
 filterwarnings =
   error
   ignore:::pytest_doctestplus
+  # vvv warnings from PINT that we cannot help.
   ignore:::pint
+  ignore:elementwise == comparison failed and returning scalar instead:FutureWarning
+  # vvv general numpy warnings
   ignore:numpy.ufunc size changed:RuntimeWarning
   ignore:numpy.ndarray size changed:RuntimeWarning
   # vvv for astropy 4.0.1 and numpy 1.19

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ description =
 deps =
 
     oldestdeps: baseband==4.0.*
-    oldestdeps: astropy==4.0  # no .* since 4.0.1 does not work with PINT.
+    oldestdeps: astropy==4.0.*
     oldestdeps: numpy==1.17.*
 
     basebanddev: git+https://github.com/mhvk/baseband.git#egg=baseband


### PR DESCRIPTION
We're now well past 4.0.1 where PINT had trouble.