### PR TITLE
Get Phase.__str__ to work at least in basic fashion

### DIFF
--- a/baseband_tasks/phases/phase.py
+++ b/baseband_tasks/phases/phase.py
@@ -313,7 +313,13 @@ class Phase(Angle):
             " * 1j" if self.imaginary else '')
 
     def __str__(self):
-        return self.to_string()
+        # Override Angle, since one cannot override the formatter for
+        # structured dtype in array2string.
+        def formatter(x):
+            return x.view(self.dtype).to_string()
+
+        return np.array2string(self.view(f"V{self.dtype.itemsize}"),
+                               formatter={'all': formatter}) + self._unitstr
 
     def __format__(self, format_spec):
         """Format a phase, special-casing the float format.

--- a/baseband_tasks/tests/test_phase_class.py
+++ b/baseband_tasks/tests/test_phase_class.py
@@ -679,6 +679,20 @@ class TestPhaseString(PhaseSetup):
         with pytest.raises(ValueError):
             Phase.from_string(item)
 
+    @pytest.mark.parametrize('imag', (True, False))
+    def test_str_works(self, imag):
+        str(self.phase * 1j if imag else self.phase)
+
+    @pytest.mark.parametrize('imag', (True, False))
+    def test_repr_works(self, imag):
+        repr(self.phase * 1j if imag else self.phase)
+
+    @pytest.mark.parametrize('imag', (True, False))
+    def test_str(self, imag):
+        s = str(self.phase * 1j if imag else self.phase)
+        assert s.count('j') == (self.phase.size if imag else 0)
+        assert s.endswith('cycle')
+
 
 class TestFractionalPhase(PhaseSetup):
     """Since FractionalPhase is a subclass of Longitude, only limited tests."""


### PR DESCRIPTION
Fixes #216 

Not very pretty but easiest way to work around fact that `np.array2string` does not allow one to override formatting of structured dtype.