### PR TITLE
Allow float shifts in SampleShift, rounding those to integer.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ New Features
   apply time shifts, including possible time delay phase rotations. [#225]
 
 - Add a simpler ``SampleShift`` task that just shifts channels by integer
-  number of samples. [#226]
+  number of samples. [#226, #235]
 
 - Streams can now carry meta-data in a ``meta`` attribute.  This includes
   information on ``frequency``, ``sideband``, and ``polarization``, all

--- a/baseband_tasks/tests/test_sampling.py
+++ b/baseband_tasks/tests/test_sampling.py
@@ -686,14 +686,18 @@ class TestSampleShift:
         resampled = resampler.read(20)
         assert_allclose(shifted, resampled)
 
-    def test_non_integer_shift(self):
-        shifter1 = SampleShift(self.ih, np.array([1., 2., 3.25]))
-        comparison = SampleShift(self.ih, np.array([1, 2, 3]))
+    @pytest.mark.parametrize('fshift, ishift', [
+        (np.array([1., 2., 3.25]), [1, 2, 3]),
+        (np.array([[-1.9], [-5.], [5.25], [3.49], [-1.2]]),
+         np.reshape([-2, -5, 5, 3, -1], (-1, 1)))])
+    def test_non_integer_shift(self, fshift, ishift):
+        shifter1 = SampleShift(self.ih, fshift)
+        comparison = SampleShift(self.ih, ishift)
         assert np.all(shifter1._shift == comparison._shift)
         data1 = shifter1.read()
         expected = comparison.read()
         assert np.all(data1 == expected)
-        shifter2 = SampleShift(self.ih, [1., 2., 3.25] / self.ih.sample_rate)
+        shifter2 = SampleShift(self.ih, fshift / self.ih.sample_rate)
         assert np.all(shifter2._shift == comparison._shift)
         data2 = shifter2.read()
         assert np.all(data2 == expected)


### PR DESCRIPTION
@luojing1211 - this is what I had in mind for allowing `float` input. I think the usage is quite obvious, and also consistent with how `stream.seek` rounds to the nearest sample too.